### PR TITLE
Update aws_cli_v2.sls rules

### DIFF
--- a/ash-linux/el8/VendorSTIG/aws_cli_v2.sls
+++ b/ash-linux/el8/VendorSTIG/aws_cli_v2.sls
@@ -31,7 +31,7 @@ Exempt AWS CLI v2 From fapolicyd ({{ fileType }}):
       - cmd: 'Reload fapolicyd config'
     - ignore_if_missing: True
     - pattern: '^(allow\s*perm=).*(\s*all\s*:\s*dir=\/usr\/local\/aws-cli\/v2\/\s*type=application\/x-{{ fileType }}\s*trust\s*1.*$)'
-    - repl: 'allow perm=any all : dir=/usr/local/aws-cli/v2/ ftype=application/x-{{ fileType }} trust=1'
+    - repl: 'allow perm=any all : dir=/usr/local/aws-cli/v2/ ftype=application/x-{{ fileType }}'
     - require:
       - file: 'Ensure fapolicyd exception-file exists'
 {%- endfor %}

--- a/ash-linux/el8/VendorSTIG/aws_cli_v2.sls
+++ b/ash-linux/el8/VendorSTIG/aws_cli_v2.sls
@@ -31,7 +31,7 @@ Exempt AWS CLI v2 From fapolicyd ({{ fileType }}):
       - cmd: 'Reload fapolicyd config'
     - ignore_if_missing: True
     - pattern: '^(allow\s*perm=).*(\s*all\s*:\s*dir=\/usr\/local\/aws-cli\/v2\/\s*type=application\/x-{{ fileType }}\s*trust\s*1.*$)'
-    - repl: 'allow perm=any all : dir=/usr/local/aws-cli/v2/ type=application/x-{{ fileType }} trust 1'
+    - repl: 'allow perm=any all : dir=/usr/local/aws-cli/v2/ ftype=application/x-{{ fileType }} trust=1'
     - require:
       - file: 'Ensure fapolicyd exception-file exists'
 {%- endfor %}


### PR DESCRIPTION
correct type to ftype and add equal to trust value.

Without these changes, these errors occur on fapolicyd rule reloads:

> fapolicyd[17873]: Field type (type) is unknown in line 7

> fapolicyd[17873]: '=' is missing for field trust, in line 7